### PR TITLE
Version 2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [v2.0.0] - WebForms API v1.1.0-1.0.4 - 2024-11-20
+### Changed
+- Added support for version v1.1.0-1.0.4 of the DocuSign WebForms API.
+- Updated the SDK release version.
+
+## Important Action Required
+- User needs to update the base URL in your codebase (if passing to SDK explicitly) and remove the /v1.1 component at the end of the URL for the SDK to work properly with this release.
+
 ## [v2.0.0rc1] - WebForms API v1.1.0-1.0.4 - 2024-09-24
 ### Changed
 - Added support for version v1.1.0-1.0.4 of the DocuSign WebForms API.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This client SDK is provided as open source, which enables you to customize its f
 <a id="versionInformation"></a>
 ### Version Information
 - **API version**: 1.1.0
-- **Latest SDK version**: 2.0.0rc1
+- **Latest SDK version**: 2.0.0
 
 <a id="requirements"></a>
 ## Requirements

--- a/docusign_webforms/client/configuration.py
+++ b/docusign_webforms/client/configuration.py
@@ -116,9 +116,9 @@ class Configuration(object):
         python_version = platform.python_version()
 
         if six.PY3:
-            self.user_agent = "Swagger-Codegen/1.1.0/2.0.0rc1/python3/" + f"{python_version}"
+            self.user_agent = "Swagger-Codegen/1.1.0/2.0.0/python3/" + f"{python_version}"
         else:
-            self.user_agent = "Swagger-Codegen/1.1.0/2.0.0rc1/python2/" + f"{python_version}"
+            self.user_agent = "Swagger-Codegen/1.1.0/2.0.0/python2/" + f"{python_version}"
 
 
     @classmethod
@@ -274,5 +274,5 @@ class Configuration(object):
                "OS: {env}\n"\
                "Python Version: {pyversion}\n"\
                "Version of the API: 1.1.0\n"\
-               "SDK Package Version: 2.0.0rc1".\
+               "SDK Package Version: 2.0.0".\
                format(env=sys.platform, pyversion=sys.version)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 from setuptools import setup, find_packages, Command, os  # noqa: H301	
 
 NAME = "docusign-webforms"
-VERSION = "2.0.0rc1"
+VERSION = "2.0.0"
 # To install the library, run the following
 #
 # python setup.py install


### PR DESCRIPTION
### Changed
- Added support for version v1.1.0-1.0.4 of the DocuSign WebForms API.
- Updated the SDK release version.

## Important Action Required
- User needs to update the base URL in your codebase (if passing to SDK explicitly) and remove the /v1.1 component at the end of the URL for the SDK to work properly with this release.
